### PR TITLE
Support Hardware Decoding for c2.rk decoders

### DIFF
--- a/android/ijkplayer/ijkplayer-java/src/main/java/tv/danmaku/ijk/media/player/IjkMediaCodecInfo.java
+++ b/android/ijkplayer/ijkplayer-java/src/main/java/tv/danmaku/ijk/media/player/IjkMediaCodecInfo.java
@@ -149,7 +149,9 @@ public class IjkMediaCodecInfo {
 
         name = name.toLowerCase(Locale.US);
         int rank = RANK_NO_SENSE;
-        if (!name.startsWith("omx.")) {
+        if (name.startsWith("c2.rk.")) {
+            rank = RANK_ACCEPTABLE;
+        } else if (!name.startsWith("omx.")) {
             rank = RANK_NON_STANDARD;
         } else if (name.startsWith("omx.pv")) {
             rank = RANK_SOFTWARE;

--- a/android/ijkplayer/ijkplayer-java/src/main/java/tv/danmaku/ijk/media/player/IjkMediaPlayer.java
+++ b/android/ijkplayer/ijkplayer-java/src/main/java/tv/danmaku/ijk/media/player/IjkMediaPlayer.java
@@ -1420,7 +1420,7 @@ public final class IjkMediaPlayer extends AbstractMediaPlayer {
             }
 
             if (bestCodec.mRank < IjkMediaCodecInfo.RANK_LAST_CHANCE) {
-                DebugLog.w(TAG, String.format(Locale.US, "unaccetable codec: %s", bestCodec.mCodecInfo.getName()));
+                DebugLog.w(TAG, String.format(Locale.US, "unacceptable codec: %s", bestCodec.mCodecInfo.getName()));
                 return null;
             }
 


### PR DESCRIPTION
使得可以使用 H96 MAX V58 这个 TV Box 里面的硬解码器（以 c2.rk. 开头的。）