### PR TITLE
Update Gradle versions to use latest Java JDK 17.0.6 in Android Studio

### DIFF
--- a/android/ijkplayer/build.gradle
+++ b/android/ijkplayer/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.2'
 
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'

--- a/android/ijkplayer/gradle/wrapper/gradle-wrapper.properties
+++ b/android/ijkplayer/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jul 10 14:23:31 CST 2021
+#Mon May 15 16:21:40 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
成功编译出 fijkplayer-full-release.aar 并在本地测试过 Video Wall app 没问题。
https://turingvideo.atlassian.net/wiki/spaces/TU/pages/1926889552/Compile+for+Android